### PR TITLE
Updating creditcost of a game by an admin is now available

### DIFF
--- a/ProjetBryanKevin/Classes/VideoGame.cs
+++ b/ProjetBryanKevin/Classes/VideoGame.cs
@@ -6,6 +6,7 @@ using System.Text;
 using System.Threading.Tasks;
 using System.Data;
 using ProjetBryanKevin.DAO;
+using System.Collections.ObjectModel;
 
 namespace ProjetBryanKevin.Classes
 {
@@ -90,5 +91,12 @@ namespace ProjetBryanKevin.Classes
             DAO_VideoGame dao = new DAO_VideoGame();
             return dao.CheckDuplicate(this);
         }
+
+        internal bool Update()
+        {
+            DAO_VideoGame dao = new DAO_VideoGame();
+            return dao.Update(this);
+        }
+
     }
 }

--- a/ProjetBryanKevin/DAO/DAO_Loan.cs
+++ b/ProjetBryanKevin/DAO/DAO_Loan.cs
@@ -39,8 +39,8 @@ namespace ProjetBryanKevin.DAO
                     {
                         Debug.Print("Succesful LOAN INSERT");
                         SqlCommand selectQuery = new SqlCommand("SELECT * FROM dbo.Loan WHERE startDate = @startDate AND endDate = @endDate AND idCopy = @idCopy AND idBorrower = @idBorrower AND idLender = @idLender", connection);
-                        selectQuery.Parameters.AddWithValue("startDate", loan.StartDate.ToString("ddMMyyyy HH:mm:ss"));
-                        selectQuery.Parameters.AddWithValue("endDate", loan.EndDate.ToString("ddMMyyyy HH:mm:ss"));
+                        selectQuery.Parameters.AddWithValue("startDate", loan.StartDate.ToString("yyyyMMdd HH:mm:ss"));
+                        selectQuery.Parameters.AddWithValue("endDate", loan.EndDate.ToString("yyyyMMdd HH:mm:ss"));
                         selectQuery.Parameters.AddWithValue("idCopy", loan.Copy.IdCopy);
                         selectQuery.Parameters.AddWithValue("idBorrower", loan.Borrower.Id);
                         selectQuery.Parameters.AddWithValue("idLender", loan.Lender.Id);
@@ -244,7 +244,7 @@ namespace ProjetBryanKevin.DAO
                 {
                     SqlCommand command = new SqlCommand("SELECT * FROM dbo.Loan WHERE idCopy = @idCopy AND startDate = @startDate", connection);
                     command.Parameters.AddWithValue("idCopy", loan.Copy.IdCopy);
-                    command.Parameters.AddWithValue("startDate", loan.StartDate.ToString("ddMMyyyy HH:mm:ss"));
+                    command.Parameters.AddWithValue("startDate", loan.StartDate.ToString("yyyyMMdd HH:mm:ss"));
                     connection.Open();
                     using (SqlDataReader reader = command.ExecuteReader())
                     {

--- a/ProjetBryanKevin/DAO/DAO_VideoGame.cs
+++ b/ProjetBryanKevin/DAO/DAO_VideoGame.cs
@@ -6,6 +6,7 @@ using System.Data;
 using System.Text;
 using System.Threading.Tasks;
 using System.Diagnostics;
+using System.Collections.ObjectModel;
 
 namespace ProjetBryanKevin.DAO
 {
@@ -165,14 +166,14 @@ namespace ProjetBryanKevin.DAO
                 {
                     SqlCommand command = new SqlCommand("UPDATE dbo.VideoGame " +
                         "SET name = @name, creditCost = @creditCost, console = @console " +
-                        "WHERE idVideoGame = @idVideoGame");
+                        "WHERE idVideoGame = @idVideoGame", connection);
                     command.Parameters.AddWithValue("idVideoGame", updatedVideoGame.IdVideoGame);
                     command.Parameters.AddWithValue("name", updatedVideoGame.Name);
                     command.Parameters.AddWithValue("creditCost", updatedVideoGame.CreditCost);
                     command.Parameters.AddWithValue("console", updatedVideoGame.Console);
                     connection.Open();
-                    bool isUpdated = command.ExecuteNonQuery() > 0 ? true : false;
-
+                    int rowsAffected = command.ExecuteNonQuery();
+                    bool isUpdated = rowsAffected > 0 ? true : false;
                     return isUpdated;
                 }
             }

--- a/ProjetBryanKevin/Pages/AdministratorPages/UpdateCreditCostWindow.xaml
+++ b/ProjetBryanKevin/Pages/AdministratorPages/UpdateCreditCostWindow.xaml
@@ -1,0 +1,22 @@
+﻿<Window x:Class="ProjetBryanKevin.Pages.AdministratorPages.UpdateCreditCostWindow"
+        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+        xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+        xmlns:local="clr-namespace:ProjetBryanKevin.Pages.AdministratorPages"
+        mc:Ignorable="d"
+        Title="Changement du coût en crédit d'un jeu" Height="300" Width="400" Background="#FF86726B">
+    <Grid Margin="0,0,0,-6">
+        <Grid.ColumnDefinitions>
+            <ColumnDefinition/>
+            <ColumnDefinition Width="0*"/>
+        </Grid.ColumnDefinitions>
+        <Label Content="Nom du jeu" HorizontalAlignment="Left" Margin="20,37,0,0" VerticalAlignment="Top" Height="32" Width="112" FontSize="15" RenderTransformOrigin="0.722,0.533" Foreground="White"/>
+        <TextBox x:Name="GameName" IsEnabled="False" HorizontalAlignment="Left" Height="26" Margin="145,37,0,0" TextWrapping="Wrap" VerticalAlignment="Top" Width="224" AutomationProperties.IsRequiredForForm="True" FontSize="15"/>
+        <Label Content="Console" HorizontalAlignment="Left" Margin="20,90,0,0" VerticalAlignment="Top" Height="32" Width="112" FontSize="15" RenderTransformOrigin="0.232,0.554" Foreground="White"/>
+        <TextBox x:Name="ConsoleType" IsEnabled="False" HorizontalAlignment="Left" Height="26" Margin="200,93,0,0" TextWrapping="Wrap" VerticalAlignment="Top" Width="169" AutomationProperties.IsRequiredForForm="True" FontSize="15"/>
+        <Button Name="UpdateCredit"  Content="Valider" Click="UpdateCredit_Click"  HorizontalAlignment="Center" VerticalAlignment="Top" Margin="0,212,0,0" Height="49" Width="348" Background="#FF515959" Foreground="#FFF1EEEE"/>
+        <Label Content="Cout en crédit (par semaine)" HorizontalAlignment="Left" Margin="20,145,0,0" VerticalAlignment="Top" Height="32" Width="202" FontSize="15" RenderTransformOrigin="0.232,0.554" Foreground="White"/>
+        <TextBox x:Name="CreditCost" PreviewTextInput="ValidateInputCost" IsEnabled="True" HorizontalAlignment="Left" Height="26" Margin="309,148,0,0" TextWrapping="Wrap" VerticalAlignment="Top" Width="60" AutomationProperties.IsRequiredForForm="True" FontSize="15"/>
+    </Grid>
+</Window>

--- a/ProjetBryanKevin/Pages/AdministratorPages/UpdateCreditCostWindow.xaml.cs
+++ b/ProjetBryanKevin/Pages/AdministratorPages/UpdateCreditCostWindow.xaml.cs
@@ -1,0 +1,55 @@
+﻿using ProjetBryanKevin.Classes;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Text.RegularExpressions;
+using System.Threading.Tasks;
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Data;
+using System.Windows.Documents;
+using System.Windows.Input;
+using System.Windows.Media;
+using System.Windows.Media.Imaging;
+using System.Windows.Shapes;
+
+namespace ProjetBryanKevin.Pages.AdministratorPages
+{
+    /// <summary>
+    /// Logique d'interaction pour UpdateCreditCostWindow.xaml
+    /// </summary>
+    public partial class UpdateCreditCostWindow : Window
+    {
+        private VideoGame videoGame;
+
+        public UpdateCreditCostWindow(VideoGame videoGame)
+        {
+            InitializeComponent();
+            this.videoGame = videoGame;
+            GameName.Text = videoGame.Name;
+            ConsoleType.Text = videoGame.Console;
+            CreditCost.Text = videoGame.CreditCost.ToString();
+        }
+
+        private void UpdateCredit_Click(object sender, RoutedEventArgs e)
+        {
+            if(CreditCost.Text == "")
+            {
+                return;
+            }
+            int newCreditCost = Int32.Parse(CreditCost.Text);
+            VideoGame updatedVideoGame = new VideoGame(videoGame.IdVideoGame, videoGame.Name, newCreditCost, videoGame.Console);
+            updatedVideoGame.Update();
+            MessageBox.Show("Changement effectué!");
+            this.Close();
+
+        }
+
+        private void ValidateInputCost(object sender, TextCompositionEventArgs e)
+        {
+            Regex regex = new Regex("[^0-9]+");
+            e.Handled = regex.IsMatch(e.Text);
+        }
+    }
+}

--- a/ProjetBryanKevin/Pages/AdministratorPages/UpdateVideoGameCredit.xaml
+++ b/ProjetBryanKevin/Pages/AdministratorPages/UpdateVideoGameCredit.xaml
@@ -16,13 +16,13 @@
           ItemsSource="{Binding Source=videoGames}"
           AutoGenerateColumns="False" CanUserResizeColumns="True" Margin="0,91,0,0" >
             <DataGrid.Columns>
-                <DataGridTextColumn Header="Nom du jeux" Binding="{Binding Name}"/>
-                <DataGridTextColumn Header="Console" Binding="{Binding Console}"/>
-                <DataGridTextColumn Header="Nombre de crédit" Binding="{Binding CreditCost}"/>
+                <DataGridTextColumn x:Name="Name" Header="Nom du jeux" Binding="{Binding Name}"/>
+                <DataGridTextColumn x:Name="Console" Header="Console" Binding="{Binding Console}"/>
+                <DataGridTextColumn x:Name="CreditCost" Header="Nombre de crédit" Binding="{Binding CreditCost}"/>
                 <DataGridTemplateColumn>
                     <DataGridTemplateColumn.CellTemplate>
                         <DataTemplate>
-                            <Button x:Name="Modification" Click="ButtonModification" Content="Modifier les crédits"/>
+                            <Button x:Name="Modification" Click="ButtonModification_Click" Content="Modifier les crédits"/>
                         </DataTemplate>
                     </DataGridTemplateColumn.CellTemplate>
                 </DataGridTemplateColumn>

--- a/ProjetBryanKevin/Pages/AdministratorPages/UpdateVideoGameCredit.xaml.cs
+++ b/ProjetBryanKevin/Pages/AdministratorPages/UpdateVideoGameCredit.xaml.cs
@@ -1,6 +1,7 @@
 ﻿using ProjetBryanKevin.Classes;
 using ProjetBryanKevin.DAO;
 using ProjetBryanKevin.Factory;
+using ProjetBryanKevin.Pages.AdministratorPages;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -23,17 +24,27 @@ namespace ProjetBryanKevin.Pages.Administrator
     /// </summary>
     public partial class UpdateVideoGameCredit : Page
     {
+        List<VideoGame> videoGames;
         public UpdateVideoGameCredit()
         {
             InitializeComponent();
-            List<VideoGame> videoGames = VideoGame.GetAllVideoGames();
+            videoGames = VideoGame.GetAllVideoGames();
             dataGridVideoGame.ItemsSource = videoGames;
         }
 
-        private void ButtonModification(object sender, RoutedEventArgs e)
+        private void ButtonModification_Click(object sender, RoutedEventArgs e)
         {
-           
-
+            VideoGame vgToUpdate = (VideoGame) dataGridVideoGame.SelectedItem;
+            MessageBoxResult res = MessageBox.Show("Voulez-vous modifier la valeur du jeu " + vgToUpdate.Name + " sur " + vgToUpdate.Console + " ?","Changement de coût en crédit",MessageBoxButton.YesNoCancel, MessageBoxImage.Question);
+            switch (res)
+            {
+                case MessageBoxResult.Yes:
+                    UpdateCreditCostWindow updateCreditCostWindow = new UpdateCreditCostWindow(vgToUpdate);
+                    updateCreditCostWindow.Show();
+                    break;
+                default:
+                    break;
+            }
         }
     }
 }


### PR DESCRIPTION
La fonction pour mettre à jour les crédits d'un jeu par l'administrateur fonctionne. Par contre, l'affichage ne s'actualise pas quand l'admin retourne sur la liste des jeux. 